### PR TITLE
Allow the popover-position breakpoint to be specified with a variable

### DIFF
--- a/styles/_littlefoot-content.scss
+++ b/styles/_littlefoot-content.scss
@@ -102,38 +102,40 @@
     }
   }
 
-  @media (max-width: 720px) {
-    border-radius: 0;
-    border-width: 1px 0 0;
-    bottom: 0;
-    left: 0 !important;
-    margin: 0;
-    opacity: 1;
-    position: fixed;
-    right: auto;
-    top: auto;
-    transform: translateY(100%);
-    transition: transform .3s ease;
-    width: 100%;
-
-    &.is-active {
-      transform: translateY(0);
-    }
-
-    .littlefoot-footnote__wrapper {
-      margin: 0 0 0 50%;
-      max-width: 100% !important;
-      transform: none;
-      width: 100%;
-    }
-
-    .littlefoot-footnote__wrapper,
-    .littlefoot-footnote__content {
+  @if $popover-bottom-breakpoint {
+    @media (max-width: $popover-bottom-breakpoint) {
       border-radius: 0;
-    }
+      border-width: 1px 0 0;
+      bottom: 0;
+      left: 0 !important;
+      margin: 0;
+      opacity: 1;
+      position: fixed;
+      right: auto;
+      top: auto;
+      transform: translateY(100%);
+      transition: transform .3s ease;
+      width: 100%;
 
-    .littlefoot-footnote__tooltip {
-      display: none;
+      &.is-active {
+        transform: translateY(0);
+      }
+
+      .littlefoot-footnote__wrapper {
+        margin: 0 0 0 50%;
+        max-width: 100% !important;
+        transform: none;
+        width: 100%;
+      }
+
+      .littlefoot-footnote__wrapper,
+      .littlefoot-footnote__content {
+        border-radius: 0;
+      }
+
+      .littlefoot-footnote__tooltip {
+        display: none;
+      }
     }
   }
 }

--- a/styles/_littlefoot-variables.scss
+++ b/styles/_littlefoot-variables.scss
@@ -49,6 +49,9 @@ $popover-scroll-indicator-bottom-position: .45em !default;
 $popover-scrolly-fade-gradient-start-location: 50% !default;
 $popover-scroll-indicator-padding: (($popover-padding-content-horizontal / 2) - ($popover-scroll-indicator-width / 2)) !default;
 
+// POPOVER-AT-BOTTOM STYLING
+$popover-bottom-breakpoint: 720px !default; // The window width below which popovers will start displaying at the bottom. Set to "false" to display normal popovers for all window sizes.
+
 // TRANSITIONS
 $popover-transition-default-duration: .25s !default;
 $popover-scroll-indicator-transition-properties: opacity !default;


### PR DESCRIPTION
This commit adds a `$popover-bottom-breakpoint` variable. If set to a width, this value is the window width below which popovers will be shown at the bottom of the screen. If set to `false`, popovers will never be shown at the bottom, no matter how narrow the screen is. The default value is 720 pixels, which matches the previous Littlefoot behavior—this change is completely backward compatible.
