### PR TITLE
Fix bottom padding issue on Firefox

### DIFF
--- a/styles/_littlefoot-content.scss
+++ b/styles/_littlefoot-content.scss
@@ -207,6 +207,14 @@
   *:last-child {
     margin-bottom: 0;
   }
+
+  .is-scrollable & {
+    padding-bottom: 0;
+
+    *:last-child {
+      margin-bottom: $popover-padding-content-bottom;
+    }
+  }
 }
 
 // A triangular shape pointing towards the footnote button.


### PR DESCRIPTION
This PR fixes issue #21 for me (in Firefox 67 on macOS) and maintains the previous (good) appearance under Safari 12 and Chrome 75.