### PR TITLE
docs: replace Chris Sauvé link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Dependency Status](https://david-dm.org/goblindegook/littlefoot.svg)](https://david-dm.org/goblindegook/littlefoot)
 [![devDependency Status](https://david-dm.org/goblindegook/littlefoot/dev-status.svg)](https://david-dm.org/goblindegook/littlefoot#info=devDependencies)
 
-littlefoot is a lightweight JavaScript library that creates exceptional footnotes. It was forked from [Bigfoot.js](https://github.com/lemonmade/bigfoot/) by [Chris Sauvé](http://cmsauve.com/projects) and does not require jQuery.
+littlefoot is a lightweight JavaScript library that creates exceptional footnotes. It was forked from [Bigfoot.js](https://github.com/lemonmade/bigfoot/) by [Chris Sauvé](https://github.com/lemonmade) and does not require jQuery.
 
 Simply include the code on your pages and footnotes will be detected automatically and improved in the following ways:
 


### PR DESCRIPTION
Looks like his site is gone (it redirects to a weird ad page)