### PR TITLE
Fix a crash when there is an empty footnote

### DIFF
--- a/src/dom/document.ts
+++ b/src/dom/document.ts
@@ -105,13 +105,15 @@ function recursiveHideFootnoteContainer(element: Element): void {
   }
 }
 
-function recursiveUnmount(element: Element) {
+function recursiveUnmount(element: Element, stopElement: Element) {
   const parent = element.parentElement!
   unmount(element)
+  if (parent === stopElement)
+    return;
   const html = parent.innerHTML.replace('[]', '').replace('&nbsp;', ' ').trim()
 
   if (!html) {
-    recursiveUnmount(parent)
+    recursiveUnmount(parent, stopElement)
   }
 }
 
@@ -121,7 +123,7 @@ function prepareTemplateData<E extends Element>(
 ): [E, E, TemplateValues] {
   const content = createElementFromHTML(body.outerHTML)
   const backlinkSelector = '[href$="#' + id + '"]'
-  queryAll<E>(content, backlinkSelector).forEach(recursiveUnmount)
+  queryAll<E>(content, backlinkSelector).forEach(bl => recursiveUnmount(bl, content))
   const html = content.innerHTML.trim()
 
   return [

--- a/test/fixtures/empty.html
+++ b/test/fixtures/empty.html
@@ -3,13 +3,7 @@
     This paragraph is footnoted.
     <sup id="fnref:1"><a href="#fn:1">[1]</a></sup>
     <sup id="fnref:2"><a href="#fn:2">[2]</a></sup>
-    <!-- duplicate footnote -->
-    <sup id="fnref:2"><a href="#fn:2">[2]</a></sup>
     <sup id="fnref:3"><a href="#fn:3">[3]</a></sup>
-  </p>
-  <p>
-    This body paragraph contains
-    <a id="body-link" href="/test/fixtures/ok.html">a link</a>.
   </p>
   <aside class="footnotes">
     <hr />

--- a/test/fixtures/empty.html
+++ b/test/fixtures/empty.html
@@ -1,0 +1,34 @@
+<article>
+  <p>
+    This paragraph is footnoted.
+    <sup id="fnref:1"><a href="#fn:1">[1]</a></sup>
+    <sup id="fnref:2"><a href="#fn:2">[2]</a></sup>
+    <!-- duplicate footnote -->
+    <sup id="fnref:2"><a href="#fn:2">[2]</a></sup>
+    <sup id="fnref:3"><a href="#fn:3">[3]</a></sup>
+  </p>
+  <p>
+    This body paragraph contains
+    <a id="body-link" href="/test/fixtures/ok.html">a link</a>.
+  </p>
+  <aside class="footnotes">
+    <hr />
+    <ol>
+      <li id="fn:1">
+        <p>
+          This is footnote 1.
+          <a href="#fnref:1" class="reversefootnote">&#160;&#8617;</a>
+        </p>
+      </li>
+      <!-- These footnotes are empty with and without a paragraph. -->
+      <li id="fn:2">
+        <p>
+          <a href="#fnref:2" class="reversefootnote">&#160;&#8617;</a>
+        </p>
+      </li>
+      <li id="fn:3">
+        <a href="#fnref:3" class="reversefootnote">&#160;&#8617;</a>
+      </li>
+    </ol>
+  </aside>
+</article>

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -92,3 +92,10 @@ test('footnote button accessibility', async () => {
   expect(button).toHaveAccessibleName()
   expect(button).toHaveAccessibleDescription()
 })
+
+test('handles empty footnotes reasonably', () => {
+  setDocumentBody('empty.html')
+  littlefoot()
+  expect(document.querySelectorAll('.littlefoot')).toHaveLength(4)
+  expect(getAllButtons()).toHaveLength(4)
+})

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -96,6 +96,6 @@ test('footnote button accessibility', async () => {
 test('handles empty footnotes reasonably', () => {
   setDocumentBody('empty.html')
   littlefoot()
-  expect(document.querySelectorAll('.littlefoot')).toHaveLength(4)
-  expect(getAllButtons()).toHaveLength(4)
+  expect(document.querySelectorAll('.littlefoot')).toHaveLength(3)
+  expect(getAllButtons()).toHaveLength(3)
 })


### PR DESCRIPTION
Before this fix, if there was an empty footnote on the page, Littlefoot would crash and no footnotes would work. When people are in the process of writing a page on our site, sometimes they have an empty footnote, and it would be convenient if it would work.

Previously, when backlinks were removed from the popover copy of the footnote, it would stop removing ancestors based on when the element was empty. However, with an empty footnote, it would never stop and would throw an exception when the parent element was null, breaking all footnotes on the page.